### PR TITLE
Patch: The getDtoClass mistype in RestApiService interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,4 +194,10 @@ important notes and links.
 ## Entry 31: Creating PlaceServiceImpl implementing the PlaceService Interface
 More on:
 1. [Annotation Type @Value](https://docs.spring.io/autorepo/docs/spring-framework/3.2.8.RELEASE/javadoc-api/org/springframework/beans/factory/annotation/Value.html)
-2. 
+
+## Notes Patch: The getDtoClass mistype in RestApiService interface
+There is a mistype inside the RestApiService which **public abstract Class<T> getDotClass();** this should be 
+**public abstract Class<T> getDtoClass();** since it refers to DTO package that serves the data transfer to be used in
+service. To do this we will use **Refactor** feature to ensure safe renaming the term. However, due to risk of crashing 
+the whole app code this patches will be done in a separate branch from the rest-template-service bracnh. The new branch
+will be called rest-api-patch.

--- a/src/main/java/com/mooracle/service/resttemplate/RestApiService.java
+++ b/src/main/java/com/mooracle/service/resttemplate/RestApiService.java
@@ -9,7 +9,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 import java.util.HashMap;
 import java.util.Map;
 
-//we need to manually import static the uriEncode
+//we need to manually import static the uriEncode since it was used but not initialized
 import static com.mooracle.util.WebUtils.uriEncode;
 
 /** Entry 23: Creating REST RestApiService.java abstract class
@@ -20,7 +20,9 @@ import static com.mooracle.util.WebUtils.uriEncode;
  *  5.  The specification of the URI is what this class is intended to build
  *  6.  remember this is an abstract class meaning it needs other class to extends it
  *  7.  In the abstract class declaration there is generic used. This is still unclear what it does exactly find out more
- *  8.  We need to build com.teamtreehouse.util.WebUtils for uriEncode
+ *  8.  We need to build com.teamtreehouse.util.WebUtils for uriEncode using static calls since when it is static
+ *      uriEncode will be initialized when this class is compiled.
+ *  9.
  * */
 
 public abstract class RestApiService<T extends Dto> {
@@ -34,7 +36,7 @@ public abstract class RestApiService<T extends Dto> {
     public abstract String getApiKey();
 
     // another abstract class of the Generic T declared in the abstract class declaration above
-    public abstract Class<T> getDotClass();
+    public abstract Class<T> getDtoClass();// <- patched
 
     // buiding the RequestBuilder, then choose alt+enter create inner class and change it into public for test
     protected RequestBuilder get(String uriTemplate) {
@@ -89,7 +91,7 @@ public abstract class RestApiService<T extends Dto> {
                     .build()
                     .expand(params);
             String url = uriComponents.toUriString();
-            return restTemplate.getForObject(url, getDotClass());
+            return restTemplate.getForObject(url, getDtoClass());
         }
     }
 }

--- a/src/main/java/com/mooracle/service/resttemplate/geocoding/GeocodingServiceImpl.java
+++ b/src/main/java/com/mooracle/service/resttemplate/geocoding/GeocodingServiceImpl.java
@@ -52,7 +52,7 @@ public class GeocodingServiceImpl extends RestApiService<GeocodingResponse> impl
     }
 
     /** Note:
-     *  As mentioned above the RestApiService only has three methods: host, key and getDotClass
+     *  As mentioned above the RestApiService only has three methods: host, key and getDtoClass
      *  this will determine the sequence of data from the DTO package.
      * */
     @Override
@@ -66,7 +66,7 @@ public class GeocodingServiceImpl extends RestApiService<GeocodingResponse> impl
     }
 
     @Override
-    public Class<GeocodingResponse> getDotClass() {
+    public Class<GeocodingResponse> getDtoClass() {
         return GeocodingResponse.class;
     }
 }

--- a/src/main/java/com/mooracle/service/resttemplate/geocoding/PlaceServiceImpl.java
+++ b/src/main/java/com/mooracle/service/resttemplate/geocoding/PlaceServiceImpl.java
@@ -61,7 +61,7 @@ public class PlaceServiceImpl extends RestApiService<PlacesResponse> implements 
     }
 
     @Override
-    public Class<PlacesResponse> getDotClass() {
+    public Class<PlacesResponse> getDtoClass() {
         return PlacesResponse.class;
     }
 }


### PR DESCRIPTION
this is the patch due to the miss typing of getDtoClass abstract inner class in the RestApiService. We need to ensure that nothing is conflicting prior to merge it back to the rest-template-service